### PR TITLE
No Cache Booster and minmal Interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --host 0.0.0.0 --disable-host-check",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/src/app/configuration/configuration.component.html
+++ b/src/app/configuration/configuration.component.html
@@ -9,7 +9,7 @@
 
 
   <div *ngIf="station">
-    <mat-checkbox raised [(ngModel)]="config.sC" name="cover">Cover von Deezer Anzeigen</mat-checkbox><br>
+    <mat-checkbox raised [(ngModel)]="config.sC" name="cover">Cover von Deezer Anzeigen (Nutzung auf eigene Gefahr)</mat-checkbox><br>
     <mat-checkbox raised [(ngModel)]="config.sLI" name="live">Live-Status anzeigen</mat-checkbox><br>
     <mat-checkbox raised [(ngModel)]="config.sCS" name="show">Aktuelle Sendung anzeigen</mat-checkbox><br>
 

--- a/src/app/overview/overview.component.scss
+++ b/src/app/overview/overview.component.scss
@@ -11,7 +11,7 @@
   width: 100%;
   z-index: 5;
   padding: 5px;
-  height: 50px;
+  min-height: 50px;
   display: flex;
   color: #fafafa;
   background-color: rgba(80, 80, 80, 0.733);

--- a/src/app/overview/overview.component.ts
+++ b/src/app/overview/overview.component.ts
@@ -307,7 +307,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.http.get<any>(this.apiURI_laut + 'station/' + this.configuredStation + '/current_song?t=' + Date.now()).subscribe((res) => {
+    this.http.get<any>(this.apiURI_laut + 'station/' + this.configuredStation + '/current_song').subscribe((res) => {
       if (res && res.title) {
 
         if (res.album) {
@@ -341,7 +341,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
         }
 
         console.log(next);
-        if (next < 300) {
+        if (next < 3000) {  // Wenn das Intervall kleiner 5 Sekunden ist, erst nach 10 Sekunden anfragen
           next = 10000;   // Wenn die Berechnung falsch läuft wird ein 10 Sekunden-Intervall verwendet
         }
         if (next) {


### PR DESCRIPTION
* Remove Cache Booster from current_song endpoint
* Minimal interval of fetching song info is now 3 Sekonds. If the calculatet interval is lower 10 Seconds will be used.
* Automatic height of song info 